### PR TITLE
fixing 'array key "legacy" not found"- error when using vite3 without legacy plugin

### DIFF
--- a/src/Asset/EntrypointsLookup.php
+++ b/src/Asset/EntrypointsLookup.php
@@ -56,7 +56,7 @@ class EntrypointsLookup
 
     public function isLegacyPluginEnabled($buildName = null): bool
     {
-        return $this->getInfos($buildName)['legacy'];
+        return array_key_exists('legacy', $this->getInfos($buildName));
     }
 
     public function isProd($buildName = null): bool


### PR DESCRIPTION
fixing 'array key "legacy" not found"- error when using vite3 without legacy plugin